### PR TITLE
fixed the cold extrusion error on moves involving the idler

### DIFF
--- a/Marlin/Marlin/src/feature/msu/msu.cpp
+++ b/Marlin/Marlin/src/feature/msu/msu.cpp
@@ -151,7 +151,7 @@ void MSUMP::idler_servo_init(){
 #endif
 
 //used in the homing process. Will be used to fix the cold extrusion related bug when moving the idler
-bool MSUMP::idler_is_moving()
+bool MSUMP::idler_is_homing()
 {
   return homingIdler;
 }

--- a/Marlin/Marlin/src/feature/msu/msu.h
+++ b/Marlin/Marlin/src/feature/msu/msu.h
@@ -11,7 +11,7 @@ public:
     static void idler_servo_init();
     static void tool_change(uint8_t index);
     static void idler_home();
-    static bool idler_is_moving();
+    static bool idler_is_homing();
 
 
 

--- a/Marlin/Marlin/src/module/endstops.cpp
+++ b/Marlin/Marlin/src/module/endstops.cpp
@@ -819,7 +819,7 @@ void Endstops::update() {
     }
   }
   #if ENABLED(MSU)
-  if(msu.idler_is_moving()){
+  if(msu.idler_is_homing()){
     PROCESS_ENDSTOP_X(MAX);
   }
   #endif

--- a/Marlin/Marlin/src/module/planner.cpp
+++ b/Marlin/Marlin/src/module/planner.cpp
@@ -111,6 +111,10 @@
   #include "../feature/spindle_laser.h"
 #endif
 
+#if ENABLED(MSU)
+  #include "../feature/msu/msu.h"
+#endif
+
 // Delay for delivery of first block to the stepper ISR, if the queue contains 2 or
 // fewer movements. The delay is measured in milliseconds, and must be less than 250ms
 #define BLOCK_DELAY_FOR_1ST_MOVE 100
@@ -1778,12 +1782,13 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
   #if EITHER(PREVENT_COLD_EXTRUSION, PREVENT_LENGTHY_EXTRUDE)
     if (de) {
       #if ENABLED(PREVENT_COLD_EXTRUSION)
+        if (!msu.idler_is_homing){
         if (thermalManager.tooColdToExtrude(extruder)) {
           position.e = target.e; // Behave as if the move really took place, but ignore E part
           TERN_(HAS_POSITION_FLOAT, position_float.e = target_float.e);
           de = 0; // no difference
           SERIAL_ECHO_MSG(STR_ERR_COLD_EXTRUDE_STOP);
-        }
+        }}
       #endif // PREVENT_COLD_EXTRUSION
       #if ENABLED(PREVENT_LENGTHY_EXTRUDE)
         const float e_steps = ABS(de * e_factor[extruder]);


### PR DESCRIPTION
This function has been tested and properly works while keeping the securities enabled on all other moves. If you observe any unwanted behavior related to the cold extrusion security when doing other moves let me know. It is now limited to the idler homing moves since when doing filament changes the hot end should be above the melting point of the material used and disabling that feature would not make sense as we also need to move the actual extruder and this is not doable when the filament is cold.